### PR TITLE
EventLoop public access

### DIFF
--- a/src/main/java/tel/schich/javacan/util/EventLoop.java
+++ b/src/main/java/tel/schich/javacan/util/EventLoop.java
@@ -35,7 +35,7 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.ThreadFactory;
 
-abstract class EventLoop implements Closeable {
+public abstract class EventLoop implements Closeable {
     private final String name;
 
     private final ThreadFactory threadFactory;


### PR DESCRIPTION
To implement a new class BcmBroker in a same manner as CanBroker is implemented, public access to EventLoop class is needed.