### PR TITLE
Fixed deadlock in removeDevice function.

### DIFF
--- a/src/main/java/tel/schich/javacan/util/CanBroker.java
+++ b/src/main/java/tel/schich/javacan/util/CanBroker.java
@@ -241,17 +241,18 @@ public class CanBroker extends EventLoop {
      * @throws IOException if the native call fails
      */
     public void removeDevice(NetworkDevice device) throws IOException {
+        final RawCanChannel ch;
         synchronized (handlerLock) {
             if (!this.channelMap.containsKey(device)) {
                 throw new IllegalArgumentException("Device not known!");
             }
 
-            RawCanChannel ch = this.channelMap.remove(device);
+            ch = this.channelMap.remove(device);
             this.handlerMap.remove(ch);
-            cancel(ch);
-            lazyShutdown();
-            ch.close();
         }
+        cancel(ch);
+        lazyShutdown();
+        ch.close();
     }
 
     public boolean isEmpty() {


### PR DESCRIPTION
Function `removeDevice` previously locked the `handlerLock` of `CanBroker` class and held it while waiting on a thread to be joined in `shutdown` function of `EventLoop` class (which is called only if the last `NetworkDevice` is removed). The problem is that this function, before it starts waiting on a thread to be joined, also calls `selector.wakeup`, which in turn triggers another thread that is waiting on a `poll` function, which further calls `processEvents` function that also wants to lock the same `handlerLock` of the same class. Therefore the second thread will wait for the lock to be obtained, but the lock will never be released, since the first thread is waiting on the second thread to stop.

This fix amends this by providing more granular locking of only the shared resources `channelMap` and `handlerMap` in the `removeDevice` function, which I think is the intention behind this `handlerLock`.