### PR TITLE
Update EventLoop.java

### DIFF
--- a/src/main/java/tel/schich/javacan/util/EventLoop.java
+++ b/src/main/java/tel/schich/javacan/util/EventLoop.java
@@ -99,6 +99,11 @@ public abstract class EventLoop implements Closeable {
      */
     protected final void cancel(SelectableChannel ch) {
         ch.keyFor(selector).cancel();
+        try {
+            this.selector.selectNow();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**


### PR DESCRIPTION

[javacan-selector-test-master.zip](https://github.com/pschichtel/JavaCAN/files/4939127/javacan-selector-test-master.zip)
This addition prevents the error in the following scenario:
- Use CanBroker
- Add one CAN channel
- Do some work
- Remove the CAN channel
- Add another CAN channel
- Can't do any work

- The problem is the following:
   - Adding the interface gives you a socket number, e.g.: 24
   - Internally EPoll FD is the same as the socket number
   - Removing it after a while releases this socket number, however this number is still registered with EPoll
        - And the EPollSelectionKey is in the cancelledKeys set
   - For a new channel Linux reuses the same socket number: 24
   - Now as the broker resumes work, the poll() function first processes the cancelledKeys set
   - So it now removes the FD from EPoll, however this FD corresponds to the new socket number

Consequently the new channel does not receive any events...

I have attached a project that nicely demonstrates the problem. It uses VCAN interfaces with bash scripts to set up the interfaces. To see the issue in action comment out the selector.selectNow(); in the SelectorApp.main() function.