### PR TITLE
* Change include from <sys/poll.h> to <poll.h> for better compatibility

### DIFF
--- a/core/src/main/c/common.c
+++ b/core/src/main/c/common.c
@@ -29,7 +29,7 @@
 #include <linux/can/raw.h>
 #include <stdint.h>
 #include <string.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <unistd.h>
 


### PR DESCRIPTION
When playing with musl (https://bugs.openjdk.java.net/browse/JDK-8229469) it seems that musl library does generate a warning when including <sys/poll.h> which breaks the native .so compilation.

When investigating it seems that <poll.h> is the more "POSIX" include to use and the files are aliases in almost all targets that I checked (see https://github.com/emscripten-core/emscripten/issues/5447#issuecomment-321513332). 

This change should not hurt but help in the future to (maybe) support running on alpine linux (when adding proper code to load the proper .so when musl is detected).