### PR TITLE
Bugfix/copy listener buffer

### DIFF
--- a/epoll/src/main/java/tel/schich/javacan/util/IsotpListener.java
+++ b/epoll/src/main/java/tel/schich/javacan/util/IsotpListener.java
@@ -124,7 +124,9 @@ public class IsotpListener extends EventLoop<UnixFileDescriptor, IsotpCanChannel
                         readBuffer.clear();
                         isotp.read(readBuffer);
                         readBuffer.flip();
-                        handler.handle(isotp, readBuffer.asReadOnlyBuffer());
+                        ByteBuffer readOnlyBuffer = ByteBuffer.allocate(readBuffer.limit());
+                        readOnlyBuffer.put(readBuffer.asReadOnlyBuffer().limit(readBuffer.limit()));
+                        handler.handle(isotp, readOnlyBuffer);
                     } else {
                         LOGGER.warn("Handler not found for channel: " + ch);
                     }

--- a/epoll/src/main/java/tel/schich/javacan/util/IsotpListener.java
+++ b/epoll/src/main/java/tel/schich/javacan/util/IsotpListener.java
@@ -125,8 +125,8 @@ public class IsotpListener extends EventLoop<UnixFileDescriptor, IsotpCanChannel
                         isotp.read(readBuffer);
                         readBuffer.flip();
                         ByteBuffer readOnlyBuffer = ByteBuffer.allocate(readBuffer.limit());
-                        readOnlyBuffer.put(readBuffer.asReadOnlyBuffer().limit(readBuffer.limit()));
-                        handler.handle(isotp, readOnlyBuffer);
+                        readOnlyBuffer.put((ByteBuffer) readBuffer.rewind());
+                        handler.handle(isotp, readOnlyBuffer.asReadOnlyBuffer());
                     } else {
                         LOGGER.warn("Handler not found for channel: " + ch);
                     }


### PR DESCRIPTION
Changed IsotpListener to return a copy of the buffer. 
Otherwise multi-threading applications may run into the problem of getting the buffer written to while the previous message is still being processed. 

Maybe should be backported to version 2.X.X aswell.